### PR TITLE
http.control referenced "shared_library_name" module

### DIFF
--- a/http.control
+++ b/http.control
@@ -1,5 +1,4 @@
-
 default_version = '1.0'
-module_pathname = '$libdir/shared_library_name'
+module_pathname = '$libdir/http'
 relocatable = true
 comment = 'HTTP client for PostgreSQL, allows web page retrieval inside the database.'


### PR DESCRIPTION
`create extension http` was failing with `ERROR:  could not access file "$libdir/shared_library_name": No such file or directory`.
