### PR TITLE
Connection: close header for many bulk requests.

### DIFF
--- a/http.c
+++ b/http.c
@@ -179,6 +179,10 @@ Datum http_get(PG_FUNCTION_ARGS)
 	if ( ! (http_handle = curl_easy_init()) )
 		ereport(ERROR, (errmsg("Unable to initialize CURL")));
 
+	headers = curl_slist_append(headers, "Connection: close");
+
+	curl_easy_setopt(http_handle, CURLOPT_HTTPHEADER, headers);
+
 	/* Set the user agent */
 	curl_easy_setopt(http_handle, CURLOPT_USERAGENT, PG_VERSION_STR);
 	


### PR DESCRIPTION
Say server to close connection after http_get or http_post call. Without this PostgreSQL eats all client socket ports and we are getting connection timeout error.
