### PR TITLE
Document minimum required curl version (0.7.20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ By default a 5 second timeout is set for the completion of a request.  If a diff
 
 ### UNIX
 
-If you have PostgreSQL devel packages and CURL devel packages installed, you should have `pg_config` and `curl-config` on your path, so you should be able to just run `make`, then `make install`, then in your database `CREATE EXTENSION http`.
+If you have PostgreSQL devel packages and CURL devel packages installed (>= 0.7.20), you should have `pg_config` and `curl-config` on your path, so you should be able to just run `make`, then `make install`, then in your database `CREATE EXTENSION http`.
 
 If you already installed version 1.0 and you just want to upgrade, then `ALTER EXTENSION http UPDATE TO '1.1'`.
 


### PR DESCRIPTION
Discovered after compiling the extension at CentOS6. It provides curl 0.7.19, but the build does not fail, and the problem only arises when the module is used (it's checked at the code).