### PR TITLE
Patch for #38 ability to overwrite CABundle location

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ By default for SSL connections, the default locations used by curl to find the C
 On some systems, there may not be a default or the default is not under user control.
 This setting allows you to overwrite the CURLOPT_CAINFO used by curl.
 
-	** Windows example**
+### Windows example
     SET http.cainfo = 'C:\SSL\Certs\ca-bundle.crt';
     
-    ** Nix example **
+### UNIX example
     SET http.cainfo = '/share/ssl/ca-bundle.crt';
 
 ## Functions

--- a/README.md
+++ b/README.md
@@ -158,6 +158,18 @@ High-performance applications may wish to enable keep-alive and connection persi
 By default a 5 second timeout is set for the completion of a request.  If a different timeout is desired the following GUC variable can be used to set it in milliseconds:
 
     http.timeout_msec = 200
+    
+## CAInfo
+
+By default for SSL connections, the default locations used by curl to find the CA Bundle are searched.
+On some systems, there may not be a default or the default is not under user control.
+This setting allows you to overwrite the CURLOPT_CAINFO used by curl.
+
+	** Windows example**
+    SET http.cainfo = 'C:\SSL\Certs\ca-bundle.crt';
+    
+    ** Nix example **
+    SET http.cainfo = '/share/ssl/ca-bundle.crt';
 
 ## Functions
 

--- a/http.c
+++ b/http.c
@@ -620,7 +620,7 @@ Datum http_request(PG_FUNCTION_ARGS)
 	CURL_SETOPT(g_http_handle, CURLOPT_FOLLOWLOCATION, 1);
 	CURL_SETOPT(g_http_handle, CURLOPT_MAXREDIRS, 5);
 	
-	/* Set CABundle path if overriden by guc*/
+	/* Set CABundle path if overridden by guc*/
 	if ( g_cainfo ){
 		CURL_SETOPT(g_http_handle, CURLOPT_CAINFO, g_cainfo);
 	}


### PR DESCRIPTION
https can't be used on windows EDB builds without it.