### PR TITLE
Handle GET requests with a body.

### DIFF
--- a/expected/http.out
+++ b/expected/http.out
@@ -37,6 +37,18 @@ FROM http_get('http://httpbin.org/anything?foo=bar');
     200 | {"foo":"bar"} | "http://httpbin.org/anything?foo=bar" | "GET"
 (1 row)
 
+-- GET with data
+SELECT status,
+content::json->'args' as args,
+content::json->>'data' as data,
+content::json->'url' as url,
+content::json->'method' as method
+from http(('GET', 'http://httpbin.org/anything', NULL, 'application/json', '{"search": "toto"}'));
+ status | args |        data        |              url              | method 
+--------+------+--------------------+-------------------------------+--------
+    200 | {}   | {"search": "toto"} | "http://httpbin.org/anything" | "GET"
+(1 row)
+
 -- DELETE
 SELECT status,
 content::json->'args' AS args,

--- a/sql/http.sql
+++ b/sql/http.sql
@@ -22,6 +22,14 @@ content::json->'url' AS url,
 content::json->'method' AS method
 FROM http_get('http://httpbin.org/anything?foo=bar');
 
+-- GET with data
+SELECT status,
+content::json->'args' as args,
+content::json->>'data' as data,
+content::json->'url' as url,
+content::json->'method' as method
+from http(('GET', 'http://httpbin.org/anything', NULL, 'application/json', '{"search": "toto"}'));
+
 -- DELETE
 SELECT status,
 content::json->'args' AS args,


### PR DESCRIPTION
CURL supports sending body with a GET (which is not forbidden by the HTTP standard). For example Elastic search use this to provide a more structured format to the information we want to get.

This change should handle using GET to send data doing a request like:
`select * from http(('GET', 'http://call-services.co.uk/stats/', NULL, 'application/json', '{"number": "82632", "date-range": ["2018-03-01", "2018-04-30"]}'));`