### PR TITLE
Allocate buffer dynamically to accommodate both http header field and value 

### DIFF
--- a/http.c
+++ b/http.c
@@ -539,7 +539,7 @@ header_array_to_slist(ArrayType *array, struct curl_slist *headers)
 				header_val = pstrdup("");
 			else
 				header_val = TextDatumGetCString(values[HEADER_VALUE]);
-			total_len = strlen(header_val) + strlen(header_fld) + sizeof(char);
+			total_len = strlen(header_val) + strlen(header_fld) + sizeof(char) + sizeof(": ");
 			buffer = palloc(total_len);
 			if (buffer)
 			{

--- a/http.c
+++ b/http.c
@@ -523,7 +523,7 @@ header_array_to_slist(ArrayType *array, struct curl_slist *headers)
 		/* server to deal with. */
 		if ( ! nulls[HEADER_FIELD] )
 		{
-			char buffer[1024];
+			char buffer[4096];
 			char *header_val;
 			char *header_fld = TextDatumGetCString(values[HEADER_FIELD]);
 

--- a/http.c
+++ b/http.c
@@ -539,13 +539,17 @@ header_array_to_slist(ArrayType *array, struct curl_slist *headers)
 				header_val = pstrdup("");
 			else
 				header_val = TextDatumGetCString(values[HEADER_VALUE]);
-			total_len = strlen(header_val) + strlen(header_fld) + 16;
+			total_len = strlen(header_val) + strlen(header_fld) + sizeof(char);
 			buffer = palloc(total_len);
-			if (buffer){
+			if (buffer)
+			{
 				snprintf(buffer, total_len, "%s: %s", header_fld, header_val);
 				elog(DEBUG2, "pgsql-http: optional request header '%s'", buffer);
 				headers = curl_slist_append(headers, buffer);
-			} else {
+				pfree(buffer);
+			} 
+			else 
+			{
 				elog(ERROR, "pgsql-http: palloc(%i) failure", total_len);
 			}
 			pfree(header_fld);

--- a/http.c
+++ b/http.c
@@ -542,7 +542,7 @@ header_array_to_slist(ArrayType *array, struct curl_slist *headers)
 			total_len = strlen(header_val) + strlen(header_fld) + 16;
 			buffer = palloc(total_len);
 			if (buffer){
-				snprintf(buffer, sizeof(buffer), "%s: %s", header_fld, header_val);
+				snprintf(buffer, total_len, "%s: %s", header_fld, header_val);
 				elog(DEBUG2, "pgsql-http: optional request header '%s'", buffer);
 				headers = curl_slist_append(headers, buffer);
 			} else {

--- a/http.c
+++ b/http.c
@@ -546,7 +546,7 @@ header_array_to_slist(ArrayType *array, struct curl_slist *headers)
 				elog(DEBUG2, "pgsql-http: optional request header '%s'", buffer);
 				headers = curl_slist_append(headers, buffer);
 			} else {
-				elog(DEBUG2, "pgsql-http: Cannot palloc %i", total_len);
+				elog(ERROR, "pgsql-http: palloc(%i) failure", total_len);
 			}
 			pfree(header_fld);
 			pfree(header_val);


### PR DESCRIPTION
  When work with large http header values e.g. embedding a JWT token in http header, the value will be truncated due to the hard-coded buffer size of 1024.  
  By allocating the buffer dynamically, we can use values that are larger than 1024 bytes in http request.