### PR TITLE
Bump max header len

### DIFF
--- a/http.c
+++ b/http.c
@@ -608,7 +608,7 @@ typname_get_tupledesc(const char *extname, const char *typname)
 }
 
 
-#define RVSZ 512 /* Max length of header element */
+#define RVSZ 8192 /* Max length of header element */
 
 /**
 * Convert a string of headers separated by newlines/CRs into an


### PR DESCRIPTION
## Why change?

HTTP does not specify a max header length, leaving it up to web servers/clients to set a limit if necessary.

Currently the limit in this library is [512 bytes](https://github.com/pramsey/pgsql-http/blob/master/http.c#L611). However, this is not long enough for e.g. JWTs which routinely exceed ~a half a kilobyte in size. 

Apache, for example, enforces an [8kb maximum](http://httpd.apache.org/docs/2.2/mod/core.html#limitrequestfieldsize).