### PR TITLE
keepalive variable defined as gcc macro. It can be enabled using -DWI…

### DIFF
--- a/http.c
+++ b/http.c
@@ -176,7 +176,11 @@ static size_t http_writeback(void *contents, size_t size, size_t nmemb, void *us
 static size_t http_readback(void *buffer, size_t size, size_t nitems, void *instream);
 
 /* Global variables */
-bool g_use_keepalive;
+#if WITH_KEEPALIVE
+bool g_use_keepalive = true;
+#else
+bool g_use_keepalive = false;
+#endif
 int g_timeout_msec;
 
 CURL * g_http_handle = NULL;


### PR DESCRIPTION
Bool variables in C language, should be defined explicitly, in other case as far as I know, this will be "undefined behavior". So I think it is a good idea to define keepalive variable as a gcc macro, so later it could be switched on via -DWITH_KEEPALIVE