### PR TITLE
Allow setting CURLOPT_USERAGENT

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,29 @@ FROM
 --------+-----------------------------------------------------------
     302 | http://www.google.ch/?gfe_rd=cr&ei=ACESWLy_KuvI8zeghL64Ag
 ```
+
+Using this extension as a background automated process without supervision (e.g as a trigger) may have unintended consequences for other servers.
+It is considered a best practice to share contact information with your requests,
+so that administrators can reach you in case your HTTP calls get out of control.
+
+Certain API policies (e.g. [Wikimedia User-Agent policy](https://meta.wikimedia.org/wiki/User-Agent_policy)) may even require sharing specific contact information
+with each request. Others may disallow (via `robots.txt`) certain agents they don't recognize.
+
+For such cases you can set the `CURLOPT_USERAGENT` option
+
+```sql
+SELECT http_set_curlopt('CURLOPT_USERAGENT',
+                        'Examplebot/2.1 (+http://www.example.com/bot.html) Contact abuse@example.com');
+
+SELECT content::json ->> 'user-agent' FROM http_get('http://httpbin.org/user-agent');
+```
+```
+ status |                         user_agent
+--------+-----------------------------------------------------------
+    200 | Examplebot/2.1 (+http://www.example.com/bot.html) Contact abuse@example.com
+```
+
+
 ## Concepts
 
 Every HTTP call is a made up of an `http_request` and an `http_response`.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Select [CURL options](https://curl.haxx.se/libcurl/c/curl_easy_setopt.html) are 
 * [CURLOPT_TCP_KEEPALIVE](https://curl.haxx.se/libcurl/c/CURLOPT_TCP_KEEPALIVE.html)
 * [CURLOPT_TCP_KEEPIDLE](https://curl.haxx.se/libcurl/c/CURLOPT_TCP_KEEPIDLE.html)
 * [CURLOPT_CONNECTTIMEOUT](https://curl.haxx.se/libcurl/c/CURLOPT_CONNECTTIMEOUT.html)
+* [CURLOPT_USERAGENT](https://curl.haxx.se/libcurl/c/CURLOPT_USERAGENT.html)
+
 
 
 For example,

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ For such cases you can set the `CURLOPT_USERAGENT` option
 SELECT http_set_curlopt('CURLOPT_USERAGENT',
                         'Examplebot/2.1 (+http://www.example.com/bot.html) Contact abuse@example.com');
 
-SELECT content::json ->> 'user-agent' FROM http_get('http://httpbin.org/user-agent');
+SELECT status, content::json ->> 'user-agent' FROM http_get('http://httpbin.org/user-agent');
 ```
 ```
  status |                         user_agent

--- a/README.md
+++ b/README.md
@@ -156,28 +156,6 @@ FROM
     302 | http://www.google.ch/?gfe_rd=cr&ei=ACESWLy_KuvI8zeghL64Ag
 ```
 
-Using this extension as a background automated process without supervision (e.g as a trigger) may have unintended consequences for other servers.
-It is considered a best practice to share contact information with your requests,
-so that administrators can reach you in case your HTTP calls get out of control.
-
-Certain API policies (e.g. [Wikimedia User-Agent policy](https://meta.wikimedia.org/wiki/User-Agent_policy)) may even require sharing specific contact information
-with each request. Others may disallow (via `robots.txt`) certain agents they don't recognize.
-
-For such cases you can set the `CURLOPT_USERAGENT` option
-
-```sql
-SELECT http_set_curlopt('CURLOPT_USERAGENT',
-                        'Examplebot/2.1 (+http://www.example.com/bot.html) Contact abuse@example.com');
-
-SELECT content::json ->> 'user-agent' FROM http_get('http://httpbin.org/user-agent');
-```
-```
- status |                         user_agent
---------+-----------------------------------------------------------
-    200 | Examplebot/2.1 (+http://www.example.com/bot.html) Contact abuse@example.com
-```
-
-
 ## Concepts
 
 Every HTTP call is a made up of an `http_request` and an `http_response`.
@@ -269,6 +247,27 @@ SELECT * FROM http_list_curlopt();
 ```
 
 Will set the proxy port option for the lifetime of the database connection. You can reset all CURL options to their defaults using the `http_reset_curlopt()` function.
+
+Using this extension as a background automated process without supervision (e.g as a trigger) may have unintended consequences for other servers.
+It is considered a best practice to share contact information with your requests,
+so that administrators can reach you in case your HTTP calls get out of control.
+
+Certain API policies (e.g. [Wikimedia User-Agent policy](https://meta.wikimedia.org/wiki/User-Agent_policy)) may even require sharing specific contact information
+with each request. Others may disallow (via `robots.txt`) certain agents they don't recognize.
+
+For such cases you can set the `CURLOPT_USERAGENT` option
+
+```sql
+SELECT http_set_curlopt('CURLOPT_USERAGENT',
+                        'Examplebot/2.1 (+http://www.example.com/bot.html) Contact abuse@example.com');
+
+SELECT content::json ->> 'user-agent' FROM http_get('http://httpbin.org/user-agent');
+```
+```
+ status |                         user_agent
+--------+-----------------------------------------------------------
+    200 | Examplebot/2.1 (+http://www.example.com/bot.html) Contact abuse@example.com
+```
 
 ## Keep-Alive & Timeouts
 

--- a/http.c
+++ b/http.c
@@ -129,6 +129,7 @@ static http_curlopt settable_curlopts[] = {
 	{ "CURLOPT_TIMEOUT", NULL, CURLOPT_TIMEOUT, CURLOPT_LONG, false },
 	{ "CURLOPT_TIMEOUT_MS", NULL, CURLOPT_TIMEOUT_MS, CURLOPT_LONG, false },
 	{ "CURLOPT_CONNECTTIMEOUT", NULL, CURLOPT_CONNECTTIMEOUT, CURLOPT_LONG, false },
+    { "CURLOPT_USERAGENT", NULL, CURLOPT_USERAGENT, CURLOPT_STRING, false },
 	{ "CURLOPT_IPRESOLVE", NULL, CURLOPT_IPRESOLVE, CURLOPT_LONG, false },
 #if LIBCURL_VERSION_NUM >= 0x070903 /* 7.9.3 */
 	{ "CURLOPT_SSLCERTTYPE", NULL, CURLOPT_SSLCERTTYPE, CURLOPT_STRING, false },
@@ -766,6 +767,9 @@ http_get_handle()
 	curl_easy_setopt(handle, CURLOPT_CONNECTTIMEOUT, 1);
 	curl_easy_setopt(handle, CURLOPT_TIMEOUT_MS, 5000);
 
+    /* Set the user agent. If not set, use PG_VERSION as default */
+    curl_easy_setopt(handle, CURLOPT_USERAGENT, PG_VERSION);
+
 	if (!handle)
 		ereport(ERROR, (errmsg("Unable to initialize CURL")));
 
@@ -1012,9 +1016,6 @@ Datum http_request(PG_FUNCTION_ARGS)
 
 	/* Set the target URL */
 	CURL_SETOPT(g_http_handle, CURLOPT_URL, uri);
-
-	/* Set the user agent */
-	CURL_SETOPT(g_http_handle, CURLOPT_USERAGENT, PG_VERSION_STR);
 
 	/* Restrict to just http/https. Leaving unrestricted */
 	/* opens possibility of users requesting file:/// urls */

--- a/http.c
+++ b/http.c
@@ -768,7 +768,7 @@ http_get_handle()
 	curl_easy_setopt(handle, CURLOPT_TIMEOUT_MS, 5000);
 
     /* Set the user agent. If not set, use PG_VERSION as default */
-    curl_easy_setopt(handle, CURLOPT_USERAGENT, PG_VERSION);
+    curl_easy_setopt(handle, CURLOPT_USERAGENT, PG_VERSION_STR);
 
 	if (!handle)
 		ereport(ERROR, (errmsg("Unable to initialize CURL")));


### PR DESCRIPTION
Currently, the default user agent the extension sends is `PG_VERSION_STR` which in HTTP requests is `"PostgreSQL 13.1 on x86_64-apple-darwin20.2.0, compiled by ...."` .

Many (most?) web services wouldn't recognize it and probably return an `HTTP Error 403` forbidden.

It would make sense to allow users to define a more realistic user agent.

For example, to emulate a Chrome-like call from within Postgres one could do something like

```sql
select http_set_curlopt('CURLOPT_USERAGENT',
                        'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36');
```

and verify via 

```sql
select content::json ->> 'user-agent' FROM http_get('http://httpbin.org/user-agent');
```