### PR TITLE
Ability to add content to DELETE request

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ As seen in the examples, you can unspool the array of `http_header` tuples into 
 * `http_post(uri VARCHAR, data JSONB)` returns `http_response`
 * `http_put(uri VARCHAR, content VARCHAR, content_type VARCHAR)` returns `http_response`
 * `http_patch(uri VARCHAR, content VARCHAR, content_type VARCHAR)` returns `http_response`
-* `http_delete(uri VARCHAR)` returns `http_response`
+* `http_delete(uri VARCHAR, content VARCHAR, content_type VARCHAR))` returns `http_response`
 * `http_head(uri VARCHAR)` returns `http_response`
 * `http_set_curlopt(curlopt VARCHAR, value varchar)` returns `boolean`
 * `http_reset_curlopt()` returns `boolean`

--- a/http--1.0--1.1.sql
+++ b/http--1.0--1.1.sql
@@ -56,9 +56,9 @@ CREATE OR REPLACE FUNCTION http_put(uri VARCHAR, content VARCHAR, content_type V
     AS $$ SELECT http(('PUT', $1, NULL, $3, $2)::http_request) $$
     LANGUAGE 'sql';
 
-CREATE OR REPLACE FUNCTION http_delete(uri VARCHAR)
+CREATE OR REPLACE FUNCTION http_delete(uri VARCHAR, content VARCHAR, content_type VARCHAR)
 	RETURNS http_response
-	AS $$ SELECT http(('DELETE', $1, NULL, NULL, NULL)::http_request) $$
+	AS $$ SELECT http(('DELETE', $1, NULL, $3, $2)::http_request) $$
     LANGUAGE 'sql';
 
 CREATE OR REPLACE FUNCTION urlencode(string VARCHAR)

--- a/http--1.0--1.1.sql
+++ b/http--1.0--1.1.sql
@@ -56,9 +56,9 @@ CREATE OR REPLACE FUNCTION http_put(uri VARCHAR, content VARCHAR, content_type V
     AS $$ SELECT http(('PUT', $1, NULL, $3, $2)::http_request) $$
     LANGUAGE 'sql';
 
-CREATE OR REPLACE FUNCTION http_delete(uri VARCHAR, content VARCHAR, content_type VARCHAR)
+CREATE OR REPLACE FUNCTION http_delete(uri VARCHAR)
 	RETURNS http_response
-	AS $$ SELECT http(('DELETE', $1, NULL, $3, $2)::http_request) $$
+	AS $$ SELECT http(('DELETE', $1, NULL, NULL, NULL)::http_request) $$
     LANGUAGE 'sql';
 
 CREATE OR REPLACE FUNCTION urlencode(string VARCHAR)

--- a/http--1.4.sql
+++ b/http--1.4.sql
@@ -81,9 +81,9 @@ CREATE OR REPLACE FUNCTION http_patch(uri VARCHAR, content VARCHAR, content_type
     AS $$ SELECT @extschema@.http(('PATCH', $1, NULL, $3, $2)::@extschema@.http_request) $$
     LANGUAGE 'sql';
 
-CREATE OR REPLACE FUNCTION http_delete(uri VARCHAR)
+CREATE OR REPLACE FUNCTION http_delete(uri VARCHAR, content VARCHAR, content_type VARCHAR)
     RETURNS http_response
-    AS $$ SELECT @extschema@.http(('DELETE', $1, NULL, NULL, NULL)::@extschema@.http_request) $$
+    AS $$ SELECT @extschema@.http(('DELETE', $1, NULL, $3, $2)::@extschema@.http_request) $$
     LANGUAGE 'sql';
 
 CREATE OR REPLACE FUNCTION http_head(uri VARCHAR)

--- a/http.c
+++ b/http.c
@@ -1138,7 +1138,7 @@ Datum http_request(PG_FUNCTION_ARGS)
 		headers = header_array_to_slist(array, headers);
 	}
 
-	/* If we have a payload we send it, assuming we're either POST, GET or PUT */
+	/* If we have a payload we send it, assuming we're either POST, GET, PATCH, PUT or DELETE */
 	if ( ! nulls[REQ_CONTENT] && values[REQ_CONTENT] )
 	{
 		text *content_text;
@@ -1160,7 +1160,7 @@ Datum http_request(PG_FUNCTION_ARGS)
 		content_text = DatumGetTextP(values[REQ_CONTENT]);
 		content_size = VARSIZE_ANY_EXHDR(content_text);
 
-		if ( method == HTTP_GET || method == HTTP_POST )
+		if ( method == HTTP_GET || method == HTTP_POST || method == HTTP_DELETE )
 		{
 			/* Add the content to the payload */
 			CURL_SETOPT(g_http_handle, CURLOPT_POST, 1);
@@ -1168,7 +1168,13 @@ Datum http_request(PG_FUNCTION_ARGS)
 			{
 				/* Force the verb to be GET */
 				CURL_SETOPT(g_http_handle, CURLOPT_CUSTOMREQUEST, "GET");
+			} 
+			else if( method == HTTP_DELETE ) 
+			{
+				/* Force the verb to be DELETE */
+				CURL_SETOPT(g_http_handle, CURLOPT_CUSTOMREQUEST, "DELETE");
 			}
+			
 			CURL_SETOPT(g_http_handle, CURLOPT_POSTFIELDS, text_to_cstring(content_text));
 		}
 		else if ( method == HTTP_PUT || method == HTTP_PATCH )


### PR DESCRIPTION
# Ability to add content to DELETE request
## Previous behavior
If a `DELETE` request with content was created, the error message `illegal HTTP method` was thrown.
An example of this would be the following SQL query:

```sql
SELECT status FROM http((
  'DELETE',
  'http://httpbin.org/',
  null,
  'application/json',
  '{}'::jsonb
)::http_request);
```
## Updated behavior
A `DELETE` request with `content` and `content_type` is now executed without throwing an error.
For this the master `http_request()` in the `http.c` file has been changed.
These additional parameters are now also accepted in the SQL function `http_delete`,
making the definition now the following:
```sql
http_delete(uri VARCHAR, content VARCHAR, content_type VARCHAR);
```
Also the documentation has been updated.
## Background
According to the [Hypertext Transfer Protocol -- HTTP/1.1](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html), the use of a body in a DELETE
request is not forbidden. For this reason, the feature was added.
## References
This fixes the issue #134, for which this feature is needed.
