### PR TITLE
Set errno to 0 before strtol

### DIFF
--- a/http.c
+++ b/http.c
@@ -786,7 +786,9 @@ set_curlopt(CURL* handle, const http_curlopt *opt)
 	/* Argument is a long */
 	else if (opt->curlopt_type == CURLOPT_LONG)
 	{
-		long value_long = strtol(opt->curlopt_val, NULL, 10);
+		long value_long;
+		errno = 0;
+		value_long = strtol(opt->curlopt_val, NULL, 10);
 		if ( errno == EINVAL || errno == ERANGE )
 			elog(ERROR, "invalid integer provided for '%s'", opt->curlopt_str);
 


### PR DESCRIPTION
Refer to 'NOTES' section of https://man7.org/linux/man-pages/man3/strtol.3.html

Fixes cases where calls to the PL/pgSQL functions http_set_curlopt() and http() keep failing after errno is set. In such cases, "invalid integer provided for 'CURLOPT_XXX'" is reported in the logs, but the provided integer is in fact valid.