### PR TITLE
SUPPORT unknown types

### DIFF
--- a/http--1.5--1.6.sql
+++ b/http--1.5--1.6.sql
@@ -1,15 +1,5 @@
 
-ALTER DOMAIN http_method drop CONSTRAINT http_method_check;
-
-ALTER DOMAIN http_method add CHECK (
-    VALUE ILIKE 'get' OR
-    VALUE ILIKE 'post' OR
-    VALUE ILIKE 'put' OR
-    VALUE ILIKE 'delete' OR
-    VALUE ILIKE 'patch' OR
-    VALUE ILIKE 'head' OR
-    VALUE ILIKE 'mkcol'
-);
+ALTER DOMAIN http_method DROP CONSTRAINT IF EXISTS http_method_check;
 
 CREATE FUNCTION text_to_bytea(data TEXT)
     RETURNS BYTEA

--- a/http--1.6.sql
+++ b/http--1.6.sql
@@ -1,17 +1,6 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION http" to load this file. \quit
-
-CREATE DOMAIN http_method AS text
-CHECK (
-    VALUE ILIKE 'get' OR
-    VALUE ILIKE 'post' OR
-    VALUE ILIKE 'put' OR
-    VALUE ILIKE 'delete' OR
-    VALUE ILIKE 'patch' OR
-    VALUE ILIKE 'head' OR
-    VALUE ILIKE 'mkcol'
-);
-
+CREATE DOMAIN http_method AS text;
 CREATE DOMAIN content_type AS text
 CHECK (
     VALUE ~ '^\S+\/\S+'

--- a/http.c
+++ b/http.c
@@ -1079,8 +1079,7 @@ Datum http_request(PG_FUNCTION_ARGS)
 		elog(ERROR, "http_request.method is NULL");
 	method_str = TextDatumGetCString(values[REQ_METHOD]);
 	method = request_type(method_str);
-	elog(DEBUG2, "pgsql-http: method_str '%s'", method_str);
-	elog(DEBUG2, "pgsql-http: method '%d'", method);
+	elog(DEBUG2, "pgsql-http: method_str: '%s', method: %d", method_str, method);
 
 	/* Set up global HTTP handle */
 	g_http_handle = http_get_handle();
@@ -1209,7 +1208,7 @@ Datum http_request(PG_FUNCTION_ARGS)
 		}
 		else if (method == HTTP_UNKNOWN)
 		{
-			/** assume the user knows what they are doing and pass unchanged **/
+			/* Assume the user knows what they are doing and pass unchanged */
 			CURL_SETOPT(g_http_handle, CURLOPT_CUSTOMREQUEST, method_str);
 		}
 		else
@@ -1232,7 +1231,7 @@ Datum http_request(PG_FUNCTION_ARGS)
 		elog(ERROR, "http_request.content is NULL");
 	}
 	else if ( method == HTTP_UNKNOWN ){
-		/** assume the user knows what they are doing and pass unchanged **/
+		/* Assume the user knows what they are doing and pass unchanged */
 		CURL_SETOPT(g_http_handle, CURLOPT_CUSTOMREQUEST, method_str);
 	}
 

--- a/http.c
+++ b/http.c
@@ -97,7 +97,8 @@ typedef enum {
 	HTTP_DELETE,
 	HTTP_PUT,
 	HTTP_HEAD,
-	HTTP_PATCH
+	HTTP_PATCH,
+	HTTP_UNKNOWN
 } http_method;
 
 /* Components (and postitions) of the http_request tuple type */
@@ -424,7 +425,7 @@ request_type(const char *method)
 	else if ( strcasecmp(method, "PATCH") == 0 )
 		return HTTP_PATCH;
 	else
-		return HTTP_GET;
+		return HTTP_UNKNOWN;
 }
 
 /**
@@ -1078,8 +1079,8 @@ Datum http_request(PG_FUNCTION_ARGS)
 		elog(ERROR, "http_request.method is NULL");
 	method_str = TextDatumGetCString(values[REQ_METHOD]);
 	method = request_type(method_str);
-	elog(DEBUG2, "pgsql-http: method '%s'", method_str);
-	pfree(method_str);
+	elog(DEBUG2, "pgsql-http: method_str '%s'", method_str);
+	elog(DEBUG2, "pgsql-http: method '%d'", method);
 
 	/* Set up global HTTP handle */
 	g_http_handle = http_get_handle();
@@ -1156,7 +1157,7 @@ Datum http_request(PG_FUNCTION_ARGS)
 		headers = header_array_to_slist(array, headers);
 	}
 
-	/* If we have a payload we send it, assuming we're either POST, GET, PATCH, PUT or DELETE */
+	/* If we have a payload we send it, assuming we're either POST, GET, PATCH, PUT or DELETE or UNKNOWN */
 	if ( ! nulls[REQ_CONTENT] && values[REQ_CONTENT] )
 	{
 		text *content_text;
@@ -1206,6 +1207,11 @@ Datum http_request(PG_FUNCTION_ARGS)
 			CURL_SETOPT(g_http_handle, CURLOPT_READDATA, &si_read);
 			CURL_SETOPT(g_http_handle, CURLOPT_INFILESIZE, content_size);
 		}
+		else if (method == HTTP_UNKNOWN)
+		{
+			/** assume the user knows what they are doing and pass unchanged **/
+			CURL_SETOPT(g_http_handle, CURLOPT_CUSTOMREQUEST, method_str);
+		}
 		else
 		{
 			/* Never get here */
@@ -1225,7 +1231,12 @@ Datum http_request(PG_FUNCTION_ARGS)
 		/* If we had a content we do not reach that part */
 		elog(ERROR, "http_request.content is NULL");
 	}
+	else if ( method == HTTP_UNKNOWN ){
+		/** assume the user knows what they are doing and pass unchanged **/
+		CURL_SETOPT(g_http_handle, CURLOPT_CUSTOMREQUEST, method_str);
+	}
 
+	pfree(method_str);
 	/* Set the headers */
 	CURL_SETOPT(g_http_handle, CURLOPT_HTTPHEADER, headers);
 


### PR DESCRIPTION
 - Define a new thing called HTTP_UNKNOWN
 - If doesn't fit our defined set of methods, mark as HTTP_UNKNOWN and pass the method type thru to curl unchanged
 - Get rid of http_method domain standard type enforcement

 Closes #159