### PR TITLE
Update README.md - add note for when there are several postgresql  installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,15 @@ make
 sudo make install
 ```
 
+If there several PostgreSQL installations available, you might need to edit the Makefile before running `make` to something like this:
+
+```
+...
+#PG_CONFIG = pg_config
+PG_CONFIG = /usr/lib/postgresql/14/bin/pg_config
+...
+```
+
 ### Windows
 
 There is a build available at [postgresonline](http://www.postgresonline.com/journal/archives/371-http-extension.html), not maintained by me.


### PR DESCRIPTION

I found a previous comment about this issue here: https://github.com/pramsey/pgsql-http/issues/12#issuecomment-95651247

However I couldn't make it work. I updated `PATH` before running `make` (even doing `export PATH=/usr/lib/postgresql/14/bin:$PATH`), but when running `sudo make install` it would always see the "wrong" version.