### PR TITLE
Add ci for PostgreSQL 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         - { PGVER: 14 }
         - { PGVER: 15 }
         - { PGVER: 16 }
+        - { PGVER: 17 }
 
     steps:
 


### PR DESCRIPTION
I think PostgreSQL 17 is ahead enough that it's worthwhile to start testing.  So far no compile issues.