### PR TITLE
Fix for windows interrupt

### DIFF
--- a/http.c
+++ b/http.c
@@ -228,6 +228,12 @@ static CURL * g_http_handle = NULL;
 static int
 http_progress_callback(void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow)
 {
+#ifdef WIN32
+	if (UNBLOCKED_SIGNAL_QUEUE())
+	{
+		pgwin32_dispatch_queued_signals();
+	}
+#endif
 	/* Check the PgSQL global flags */
 	return QueryCancelPending || ProcDiePending;
 }


### PR DESCRIPTION
Put back win32 section of interrupt, otherwise windows interrupt is broken.