### PR TITLE
Add PG18 to testing harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         - { PGVER: 15 }
         - { PGVER: 16 }
         - { PGVER: 17 }
+        - { PGVER: 18 }
 
     steps:
 


### PR DESCRIPTION
I mark this as a WIP cause it's failing at the moment.

I don't know if it's something that changed recently in PG18 or this is a result of a recent change or something missed in http.  The postgis last regresses are all green on PG18.