### PR TITLE
Add WaitEventExtensionNew calls for Pg17+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: true
       matrix:
         ci:
-        - { PGVER: 13 }
         - { PGVER: 14 }
         - { PGVER: 15 }
         - { PGVER: 16 }


### PR DESCRIPTION
Makes the use of the extension more visible for long-running http() calls, as user can see them in pg_stat_statements if they are registered.