### PR TITLE
Relax check for expected size of test image

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,10 @@ insert_final_newline = true
 [*.{c,h}]
 indent_style = tab
 
+# expected output files have trailing whitespace
+[*.out]
+trim_trailing_whitespace = false
+
 # YAML files want space indentation
 [*.{yml}]
 indent_style = space

--- a/expected/http.out
+++ b/expected/http.out
@@ -181,12 +181,12 @@ WITH
   )
 SELECT
   http.content_type,
-  length(text_to_bytea(http.content)) AS length_binary
+  length(text_to_bytea(http.content)) between 5000 and 9000 AS length_binary
 FROM http, headers
 WHERE field ilike 'Content-Type';
  content_type | length_binary 
 --------------+---------------
- image/png    |          8090
+ image/png    | t
 (1 row)
 
 -- Alter options and and reset them and throw errors

--- a/sql/http.sql
+++ b/sql/http.sql
@@ -123,7 +123,7 @@ WITH
   )
 SELECT
   http.content_type,
-  length(text_to_bytea(http.content)) AS length_binary
+  length(text_to_bytea(http.content)) between 5000 and 9000 AS length_binary
 FROM http, headers
 WHERE field ilike 'Content-Type';
 


### PR DESCRIPTION
On Ubuntu's httpbin server, the file served at /image/png has a different size (5642 bytes instead of 8090). Allow some slack in the test output.

In passing, tell .editorconfig that expected output files have trailing whitespace that needs to be preserved.